### PR TITLE
feat: support branching stacks beyond base branches

### DIFF
--- a/cli/so/cmd/bottom_runner.go
+++ b/cli/so/cmd/bottom_runner.go
@@ -30,7 +30,7 @@ func (r *bottomCmdRunner) run() error {
 	r.logger.Debug("Retrieved stack info", "currentBranch", stackInfo.CurrentBranch, "fullStack", stackInfo.FullStack)
 
 	// CASE 1: On base in multi-stack environment -> selection
-	if stackInfo.FullStack == nil && stackInfo.CurrentBranch == stackInfo.BaseBranch {
+	if stackInfo.FullStack == nil {
 		if target, handled, selErr := cmdutils.ResolveTestStackSelection(stackInfo.CurrentBranch, cmdutils.PurposeBottom, testSelectStackIndexBottom, testSelectStackChildBottom); handled {
 			if selErr != nil {
 				return selErr
@@ -41,7 +41,7 @@ func (r *bottomCmdRunner) run() error {
 			return checkoutBranch(target, stackInfo.CurrentBranch)
 		}
 		if r.nonInteractive {
-			return fmt.Errorf("multiple stacks found from base branch '%s'; navigate to a specific stack branch before running this command in non-interactive mode", stackInfo.CurrentBranch)
+			return fmt.Errorf("multiple stacks found from branch '%s'; navigate to a specific stack branch before running this command in non-interactive mode", stackInfo.CurrentBranch)
 		}
 		branch, _, errSel := r.promptSelectStack(stackInfo.CurrentBranch, cmdutils.PurposeBottom)
 		if errSel != nil {
@@ -53,22 +53,7 @@ func (r *bottomCmdRunner) run() error {
 		return checkoutBranch(branch, stackInfo.CurrentBranch)
 	}
 
-	// CASE 2: Inside lineage (multi-stack env) FullStack nil -> use CurrentStack
-	if stackInfo.FullStack == nil {
-		branch, msg, navErr := cmdutils.ComputeLinearTarget(stackInfo.CurrentBranch, stackInfo.CurrentStack, cmdutils.PurposeBottom)
-		if navErr != nil {
-			return navErr
-		}
-		if branch == "" {
-			if msg != "" {
-				_, _ = fmt.Fprintf(r.stdout, "%s\n", msg)
-			}
-			return nil
-		}
-		return checkoutBranch(branch, stackInfo.CurrentBranch)
-	}
-
-	// CASE 3: Standard linear stack
+	// CASE 2: Standard linear stack
 	branch, msg, navErr := cmdutils.ComputeLinearTarget(stackInfo.CurrentBranch, stackInfo.FullStack, cmdutils.PurposeBottom)
 	if navErr != nil {
 		return navErr
@@ -89,7 +74,7 @@ func (r *bottomCmdRunner) promptSelectStack(baseBranch string, purpose cmdutils.
 		return "", true, err
 	}
 	if len(stacks) == 0 {
-		_, _ = fmt.Fprintf(r.stdout, "No stacks found starting from base branch '%s'.\n", baseBranch)
+		_, _ = fmt.Fprintf(r.stdout, "No stacks found starting from branch '%s'.\n", baseBranch)
 		return "", true, nil
 	}
 	var selectedOption string

--- a/cli/so/cmd/bottom_test.go
+++ b/cli/so/cmd/bottom_test.go
@@ -183,7 +183,7 @@ func TestBottomCommand(t *testing.T) {
 		testutils.RunCommand(t, repoPath, "git", "checkout", "main")
 		_, _, err := runSoCommandWithOutput(t, "--non-interactive", "bottom")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "multiple stacks found from base branch")
+		assert.Contains(t, err.Error(), "multiple stacks found from branch")
 	})
 
 }

--- a/cli/so/cmd/create_runner.go
+++ b/cli/so/cmd/create_runner.go
@@ -70,20 +70,6 @@ func (r *createCmdRunner) run() error {
 		return fmt.Errorf("internal error: could not determine base branch for parent '%s'", parentBranch)
 	}
 
-	// 2.5. Validate linear stack constraint: non-base branches can only have one child
-	if !isParentBase {
-		// Check if parent already has children
-		parentMap, err := git.GetAllSocleParents()
-		if err != nil {
-			return fmt.Errorf("failed to check existing branch relationships: %w", err)
-		}
-		childMap := git.BuildChildMap(parentMap)
-
-		if existingChildren, hasChildren := childMap[parentBranch]; hasChildren && len(existingChildren) > 0 {
-			return fmt.Errorf("non-base branch '%s' already has child branch(es): %v. Only base branches can have multiple children. Use 'so up' to navigate to the existing child or create a new stack from the base branch", parentBranch, existingChildren)
-		}
-	}
-
 	// 3. Determine new branch name
 	newBranchName := ""
 	if r.testBranchName != "" {

--- a/cli/so/cmd/create_test.go
+++ b/cli/so/cmd/create_test.go
@@ -103,6 +103,28 @@ func TestCreateCommand(t *testing.T) {
 
 	})
 
+	t.Run("Create branch allows multiple children on non-base branch", func(t *testing.T) {
+		repoPath, cleanup := testutils.SetupGitRepo(t)
+		defer cleanup()
+
+		testutils.RunCommand(t, repoPath, "git", "checkout", "-b", "feature/a")
+		err := runSoCommand(t, "track", "--test-parent=main")
+		require.NoError(t, err)
+
+		testutils.RunCommand(t, repoPath, "git", "checkout", "-b", "feature/b")
+		err = runSoCommand(t, "track", "--test-parent=feature/a")
+		require.NoError(t, err)
+
+		testutils.RunCommand(t, repoPath, "git", "checkout", "feature/a")
+		err = runSoCommand(t, "create", "feature/c")
+		require.NoError(t, err, "so create should allow additional children on non-base branches")
+
+		parent, _ := git.GetGitConfig("branch.feature/c.socle-parent")
+		base, _ := git.GetGitConfig("branch.feature/c.socle-base")
+		assert.Equal(t, "feature/a", parent)
+		assert.Equal(t, "main", base)
+	})
+
 	t.Run("Create branch fails if branch already exists", func(t *testing.T) {
 		repoPath, cleanup := testutils.SetupGitRepo(t)
 		defer cleanup()

--- a/cli/so/cmd/layered_branching_navigation_test.go
+++ b/cli/so/cmd/layered_branching_navigation_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/benekuehn/socle/cli/so/internal/git"
+	"github.com/benekuehn/socle/cli/so/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLayeredBranchingNavigation(t *testing.T) {
+	repoPath, cleanup := setupRepoWithLayeredBranching(t)
+	defer cleanup()
+
+	testutils.RunCommand(t, repoPath, "git", "checkout", "feature-a")
+
+	stdout, stderr, err := runSoCommandWithOutput(t, "up", "--test-select-stack-child=feature-c")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	assert.NotContains(t, stdout, "Multiple stacks available")
+	cur, err := git.GetCurrentBranch()
+	require.NoError(t, err)
+	assert.Equal(t, "feature-c", cur)
+
+	testutils.RunCommand(t, repoPath, "git", "checkout", "feature-a")
+	stdout, stderr, err = runSoCommandWithOutput(t, "top", "--test-select-stack-child=feature-b")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	cur, err = git.GetCurrentBranch()
+	require.NoError(t, err)
+	assert.Equal(t, "feature-b", cur)
+
+	testutils.RunCommand(t, repoPath, "git", "checkout", "feature-a")
+	stdout, stderr, err = runSoCommandWithOutput(t, "bottom", "--test-select-stack-child=feature-c")
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+	cur, err = git.GetCurrentBranch()
+	require.NoError(t, err)
+	assert.Equal(t, "feature-c", cur)
+}

--- a/cli/so/cmd/test_helpers.go
+++ b/cli/so/cmd/test_helpers.go
@@ -178,3 +178,34 @@ func initializeCobraAppForTest() (*cobra.Command, error) {
 	testRootCmd.Flags().AddFlagSet(trackCmd.Flags())
 	return testRootCmd, nil
 }
+
+// setupRepoWithLayeredBranching creates main -> feature-a with two children feature-b and feature-c.
+func setupRepoWithLayeredBranching(t *testing.T) (repoPath string, cleanup func()) {
+	t.Helper()
+	repoPath, cleanup = testutils.SetupGitRepo(t)
+
+	testutils.RunCommand(t, repoPath, "git", "checkout", "main")
+	testutils.RunCommand(t, repoPath, "git", "checkout", "-b", "feature-a")
+	writeFile(t, repoPath, "feature-a.txt", "feature-a content")
+	testutils.RunCommand(t, repoPath, "git", "add", ".")
+	testutils.RunCommand(t, repoPath, "git", "commit", "-m", "feat: commit on feature-a")
+	err := runSoCommand(t, "track", "--test-parent=main")
+	require.NoError(t, err, "Setup: failed to track feature-a")
+
+	testutils.RunCommand(t, repoPath, "git", "checkout", "-b", "feature-b")
+	writeFile(t, repoPath, "feature-b.txt", "feature-b content")
+	testutils.RunCommand(t, repoPath, "git", "add", ".")
+	testutils.RunCommand(t, repoPath, "git", "commit", "-m", "feat: commit on feature-b")
+	err = runSoCommand(t, "track", "--test-parent=feature-a")
+	require.NoError(t, err, "Setup: failed to track feature-b")
+
+	testutils.RunCommand(t, repoPath, "git", "checkout", "feature-a")
+	testutils.RunCommand(t, repoPath, "git", "checkout", "-b", "feature-c")
+	writeFile(t, repoPath, "feature-c.txt", "feature-c content")
+	testutils.RunCommand(t, repoPath, "git", "add", ".")
+	testutils.RunCommand(t, repoPath, "git", "commit", "-m", "feat: commit on feature-c")
+	err = runSoCommand(t, "track", "--test-parent=feature-a")
+	require.NoError(t, err, "Setup: failed to track feature-c")
+
+	return repoPath, cleanup
+}

--- a/cli/so/cmd/top_runner.go
+++ b/cli/so/cmd/top_runner.go
@@ -30,7 +30,7 @@ func (r *topCmdRunner) run() error {
 	r.logger.Debug("Retrieved stack info", "currentBranch", stackInfo.CurrentBranch, "fullStack", stackInfo.FullStack)
 
 	// CASE 1: Base branch with multiple stacks
-	if stackInfo.FullStack == nil && stackInfo.CurrentBranch == stackInfo.BaseBranch {
+	if stackInfo.FullStack == nil {
 		if target, handled, selErr := cmdutils.ResolveTestStackSelection(stackInfo.CurrentBranch, cmdutils.PurposeTop, testSelectStackIndexTop, testSelectStackChildTop); handled {
 			if selErr != nil {
 				return selErr
@@ -41,7 +41,7 @@ func (r *topCmdRunner) run() error {
 			return checkoutBranch(target, stackInfo.CurrentBranch)
 		}
 		if r.nonInteractive {
-			return fmt.Errorf("multiple stacks found from base branch '%s'; navigate to a specific stack branch before running this command in non-interactive mode", stackInfo.CurrentBranch)
+			return fmt.Errorf("multiple stacks found from branch '%s'; navigate to a specific stack branch before running this command in non-interactive mode", stackInfo.CurrentBranch)
 		}
 		branch, _, errSel := r.promptSelectStack(stackInfo.CurrentBranch, cmdutils.PurposeTop)
 		if errSel != nil {
@@ -53,22 +53,7 @@ func (r *topCmdRunner) run() error {
 		return checkoutBranch(branch, stackInfo.CurrentBranch)
 	}
 
-	// CASE 2: Inside lineage (multi-stack env) with FullStack nil -> use CurrentStack
-	if stackInfo.FullStack == nil {
-		branch, msg, navErr := cmdutils.ComputeLinearTarget(stackInfo.CurrentBranch, stackInfo.CurrentStack, cmdutils.PurposeTop)
-		if navErr != nil {
-			return navErr
-		}
-		if branch == "" {
-			if msg != "" {
-				_, _ = fmt.Fprintf(r.stdout, "%s\n", msg)
-			}
-			return nil
-		}
-		return checkoutBranch(branch, stackInfo.CurrentBranch)
-	}
-
-	// CASE 3: Standard linear stack
+	// CASE 2: Standard linear stack
 	branch, msg, navErr := cmdutils.ComputeLinearTarget(stackInfo.CurrentBranch, stackInfo.FullStack, cmdutils.PurposeTop)
 	if navErr != nil {
 		return navErr
@@ -88,7 +73,7 @@ func (r *topCmdRunner) promptSelectStack(baseBranch string, purpose cmdutils.Nav
 		return "", true, err
 	}
 	if len(stacks) == 0 {
-		_, _ = fmt.Fprintf(r.stdout, "No stacks found starting from base branch '%s'.\n", baseBranch)
+		_, _ = fmt.Fprintf(r.stdout, "No stacks found starting from branch '%s'.\n", baseBranch)
 		return "", true, nil
 	}
 	var selectedOption string

--- a/cli/so/cmd/top_test.go
+++ b/cli/so/cmd/top_test.go
@@ -151,7 +151,7 @@ func TestTopCommand(t *testing.T) {
 		testutils.RunCommand(t, repoPath, "git", "checkout", "main")
 		_, _, err := runSoCommandWithOutput(t, "--non-interactive", "top")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "multiple stacks found from base branch")
+		assert.Contains(t, err.Error(), "multiple stacks found from branch")
 	})
 
 }

--- a/cli/so/cmd/up_runner.go
+++ b/cli/so/cmd/up_runner.go
@@ -28,7 +28,7 @@ func (r *upCmdRunner) run() error {
 	r.logger.Debug("Retrieved stack info", "currentBranch", stackInfo.CurrentBranch, "fullStack", stackInfo.FullStack)
 
 	// CASE 1: On base branch with multiple stacks
-	if stackInfo.FullStack == nil && stackInfo.CurrentBranch == stackInfo.BaseBranch {
+	if stackInfo.FullStack == nil {
 		if target, handled, selErr := cmdutils.ResolveTestStackSelection(stackInfo.CurrentBranch, cmdutils.PurposeUp, testSelectStackIndex, testSelectStackChild); handled {
 			if selErr != nil {
 				return selErr
@@ -48,22 +48,7 @@ func (r *upCmdRunner) run() error {
 		return checkoutBranch(branch, stackInfo.CurrentBranch)
 	}
 
-	// CASE 2: Inside lineage (multi-stack env) with FullStack nil
-	if stackInfo.FullStack == nil {
-		branch, msg, navErr := cmdutils.ComputeLinearTarget(stackInfo.CurrentBranch, stackInfo.CurrentStack, cmdutils.PurposeUp)
-		if navErr != nil {
-			return navErr
-		}
-		if branch == "" {
-			if msg != "" {
-				_, _ = fmt.Fprintf(r.stdout, "%s\n", msg)
-			}
-			return nil
-		}
-		return checkoutBranch(branch, stackInfo.CurrentBranch)
-	}
-
-	// CASE 3: Standard linear stack
+	// CASE 2: Standard linear stack
 	branch, msg, navErr := cmdutils.ComputeLinearTarget(stackInfo.CurrentBranch, stackInfo.FullStack, cmdutils.PurposeUp)
 	if navErr != nil {
 		return navErr
@@ -84,7 +69,7 @@ func (r *upCmdRunner) promptSelectStack(baseBranch string, purpose cmdutils.Navi
 		return "", true, err
 	}
 	if len(stacks) == 0 {
-		_, _ = fmt.Fprintf(r.stdout, "No stacks found starting from base branch '%s'.\n", baseBranch)
+		_, _ = fmt.Fprintf(r.stdout, "No stacks found starting from branch '%s'.\n", baseBranch)
 		return "", true, nil
 	}
 	var selectedOption string

--- a/cli/so/internal/git/stack.go
+++ b/cli/so/internal/git/stack.go
@@ -23,164 +23,84 @@ type StackInfo struct {
 }
 
 // Invariants / Semantics:
-// - FullStack is a linear ordered slice from BaseBranch to tip when the base has <=1 child lineage.
-// - FullStack is set to nil ONLY when the currently checked out branch is a known base branch (main/master/develop)
-//   that has >1 tracked child branches, i.e. multiple independent stacks originate from it.
-//   In that case CurrentStack will contain just the base branch and navigation commands should prompt.
-// - When the current branch is NOT the base but the base has multiple child stacks, FullStack is still nil.
-//   CurrentStack then represents the lineage from the base to the current branch and navigation commands must
-//   treat it as the active linear stack without prompting for stack selection.
-// The navigation runners (up/top/bottom) implement this distinction; log command also follows these rules.
+// - FullStack is a linear ordered slice from BaseBranch to tip for the active lineage.
+// - FullStack is nil when CurrentBranch itself has multiple tracked children, because there is no
+//   single implicit "up/top/bottom" target without stack selection.
+// - CurrentStack always contains the lineage from BaseBranch to CurrentBranch.
 
 // GetStackInfo retrieves comprehensive information about the current branch stack.
 // It returns all stack-related information in a single StackInfo struct.
 func GetStackInfo() (*StackInfo, error) {
-	// 1. Get Current Branch
 	currentBranch, err := GetCurrentBranch()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current branch: %w", err)
 	}
 
-	// 2. Get all parent relationships at once
 	parentMap, err := GetAllSocleParents()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read tracking relationships: %w", err)
 	}
-
-	// Build the child map for later operations
 	childMap := BuildChildMap(parentMap)
 
-	// 3. Check if we are actually on a known base branch
 	knownBases := map[string]bool{"main": true, "master": true, "develop": true}
-	var baseBranch string
-	var currentStack []string
+	baseBranch := ""
 
 	if knownBases[currentBranch] {
 		baseBranch = currentBranch
-		currentStack = []string{baseBranch} // Stack is just the base itself
 	} else {
-		// 4. Check if current branch is tracked
 		baseConfigKey := fmt.Sprintf("branch.%s.socle-base", currentBranch)
-		baseBranchNameFromConfig, errBase := GetGitConfig(baseConfigKey)
-		isBaseNotFound := errors.Is(errBase, ErrConfigNotFound)
-
-		if isBaseNotFound {
+		baseBranch, err = GetGitConfig(baseConfigKey)
+		if errors.Is(err, ErrConfigNotFound) {
 			return nil, fmt.Errorf("current branch '%s' is not tracked by socle (missing socle-base config) and is not a known base branch.\nRun 'so track' on this branch first", currentBranch)
 		}
-		if errBase != nil {
-			return nil, fmt.Errorf("failed to read tracking base for '%s': %w", currentBranch, errBase)
-		}
-
-		baseBranch = baseBranchNameFromConfig
-
-		// 5. Build the stack by walking up the parents using the parentMap
-		currentStack = []string{currentBranch}
-		currentInLoop := currentBranch
-
-		for currentInLoop != baseBranch {
-			parent, hasParent := parentMap[currentInLoop]
-			if !hasParent {
-				return nil, fmt.Errorf("tracking information broken: parent not found for branch '%s', which is not the base '%s'. Cannot determine stack", currentInLoop, baseBranch)
-			}
-
-			// Prepend the found parent to the stack slice
-			currentStack = append([]string{parent}, currentStack...)
-
-			// Check if the parent we just added is the base branch
-			if parent == baseBranch {
-				break // We've reached the base, stack is complete
-			}
-
-			// Move up for the next iteration
-			currentInLoop = parent
-
-			// Safety break to prevent infinite loops in case of cyclic metadata
-			if len(currentStack) > 50 { // Arbitrary limit
-				return nil, fmt.Errorf("stack trace exceeds 50 levels, assuming cycle or error in tracking metadata")
-			}
+		if err != nil {
+			return nil, fmt.Errorf("failed to read tracking base for '%s': %w", currentBranch, err)
 		}
 	}
 
-	// 6. Determine the full ordered stack
-	slog.Debug("Determining full ordered stack...")
+	currentStack := []string{currentBranch}
+	for walker := currentBranch; walker != baseBranch; {
+		parent, ok := parentMap[walker]
+		if !ok {
+			return nil, fmt.Errorf("tracking information broken: parent not found for branch '%s', which is not the base '%s'. Cannot determine stack", walker, baseBranch)
+		}
+		currentStack = append([]string{parent}, currentStack...)
+		walker = parent
+		if len(currentStack) > 100 {
+			return nil, fmt.Errorf("stack trace exceeds 100 levels, assuming cycle or error in tracking metadata")
+		}
+	}
 
-	// Reconstruct the lineage from the base upwards
-	fullStack := []string{baseBranch}
-	current := baseBranch
-	visited := make(map[string]bool)
-	visited[current] = true
+	if children := childMap[currentBranch]; len(children) > 1 {
+		slog.Debug("Current branch has multiple children; full stack is ambiguous", "current", currentBranch, "children", children)
+		return &StackInfo{
+			CurrentBranch: currentBranch,
+			BaseBranch:    baseBranch,
+			CurrentStack:  currentStack,
+			FullStack:     nil,
+			ParentMap:     parentMap,
+			ChildMap:      childMap,
+		}, nil
+	}
 
+	fullStack := append([]string{}, currentStack...)
 	for {
-		children, found := childMap[current]
-		if !found || len(children) == 0 {
-			break // No more tracked children in this lineage
+		last := fullStack[len(fullStack)-1]
+		children := childMap[last]
+		if len(children) == 0 {
+			break
 		}
-
 		if len(children) > 1 {
-			if knownBases[current] {
-				// Base branch with multiple stacks.
-				// If we are CURRENTLY on the base branch itself, we cannot provide a single linear FullStack.
-				// If we are NOT on the base (i.e., navigating inside one lineage), we can still produce a FullStack
-				// by using currentStack (base->...->currentBranch) and then extending downward from currentBranch.
-				if currentBranch == current { // we are ON the base branch
-					slog.Debug("Base branch with multiple stacks detected (on base)", "base", current, "children", children)
-					return &StackInfo{
-						CurrentBranch: currentBranch,
-						BaseBranch:    baseBranch,
-						CurrentStack:  currentStack,
-						FullStack:     nil, // Signal that multiple stacks exist from base context
-						ParentMap:     parentMap,
-						ChildMap:      childMap,
-					}, nil
-				}
-				// We are inside lineage: Build full stack using known path to currentBranch then descend.
-				slog.Debug("Inside multi-stack lineage; reconstructing full lineage for current branch", "currentBranch", currentBranch)
-				fullStack = append([]string{}, currentStack...) // base->...->currentBranch
-				// Descend from currentBranch to tip
-				walker := currentBranch
-				for {
-					childList, foundChild := childMap[walker]
-					if !foundChild || len(childList) == 0 {
-						break
-					}
-					if len(childList) > 1 {
-						return nil, fmt.Errorf("non-base branch '%s' has multiple children %v, violating linear lineage assumption", walker, childList)
-					}
-					next := childList[0]
-					// Avoid duplicates if currentBranch already included
-					if next == walker {
-						return nil, fmt.Errorf("cycle detected at branch '%s' while descending lineage", walker)
-					}
-					fullStack = append(fullStack, next)
-					walker = next
-					if len(fullStack) > 100 { // safety
-						return nil, fmt.Errorf("stack reconstruction exceeded 100 branches (descending)")
-					}
-				}
-				// Finished lineage reconstruction.
-				break
-			} else {
-				// Non-base branch with multiple children - violates linear stack assumption
-				return nil, fmt.Errorf("non-base branch '%s' has multiple children %v, which violates linear stack structure. Only base branches (%v) can have multiple children", current, children, []string{"main", "master", "develop"})
-			}
+			return nil, fmt.Errorf("branch '%s' has multiple children %v; checkout one child branch to continue", last, children)
 		}
-		nextChild := children[0]
-
-		if visited[nextChild] {
-			return nil, fmt.Errorf("cycle detected in stack tracking near branch '%s'", nextChild)
-		}
-
-		fullStack = append(fullStack, nextChild)
-		visited[nextChild] = true
-		current = nextChild
-
-		if len(fullStack) > 100 { // Safety break
+		next := children[0]
+		fullStack = append(fullStack, next)
+		if len(fullStack) > 100 {
 			return nil, fmt.Errorf("stack reconstruction exceeded 100 branches, aborting")
 		}
 	}
 
 	slog.Debug("Full ordered stack identified:", "stack", fullStack)
-
 	return &StackInfo{
 		CurrentBranch: currentBranch,
 		BaseBranch:    baseBranch,
@@ -191,7 +111,7 @@ func GetStackInfo() (*StackInfo, error) {
 	}, nil
 }
 
-// GetAvailableStacksFromBase returns all available stacks that start from the given base branch
+// GetAvailableStacksFromBase returns all available stacks that start from the given branch.
 func GetAvailableStacksFromBase(baseBranch string) ([][]string, error) {
 	parentMap, err := GetAllSocleParents()
 	if err != nil {
@@ -201,7 +121,7 @@ func GetAvailableStacksFromBase(baseBranch string) ([][]string, error) {
 	childMap := BuildChildMap(parentMap)
 	children, found := childMap[baseBranch]
 	if !found || len(children) == 0 {
-		return nil, fmt.Errorf("no stacks found starting from base branch '%s'", baseBranch)
+		return nil, fmt.Errorf("no stacks found starting from branch '%s'", baseBranch)
 	}
 
 	var stacks [][]string


### PR DESCRIPTION
### Motivation
- Socle previously only allowed multiple child stacks originating from known base branches (`main`/`master`/`develop`), which prevented creating or navigating sibling branches when branching occurs at intermediate layers (e.g., A -> {B, C}).

### Description
- Allow creating sibling children from non-base parents by removing the single-child restriction in `create` (`cmd/create_runner.go`).
- Rework stack resolution in `GetStackInfo` (`internal/git/stack.go`) so any branch that has multiple tracked children yields `FullStack == nil` while preserving a valid `CurrentStack` lineage for navigation within the active lineage.
- Update navigation runners (`cmd/up_runner.go`, `cmd/top_runner.go`, `cmd/bottom_runner.go`) to treat `FullStack == nil` as a selection-needed context regardless of whether the branch is a known base, and generalize user-facing wording from "base branch" to "branch" where appropriate.
- Add regression tests: layered branching navigation test `cmd/layered_branching_navigation_test.go`, a `create` test to verify sibling creation from a non-base parent (`cmd/create_test.go`), and a helper `setupRepoWithLayeredBranching` in `cmd/test_helpers.go`.

### Testing
- Ran the Go test suite for the CLI module with `go test ./...` inside `cli/so`; the tests completed successfully and relevant command tests passed (no failing tests).
- Added unit tests verifying layered branching navigation and sibling-creation behavior which ran as part of the test run and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b61f9e40dc8332ad9883e14bb91d52)