### PR TITLE
fix: make `so create` non-interactive when no TTY is available

### DIFF
--- a/cli/so/cmd/create_runner.go
+++ b/cli/so/cmd/create_runner.go
@@ -9,6 +9,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/benekuehn/socle/cli/so/internal/git"
 	"github.com/benekuehn/socle/cli/so/internal/ui"
+	"github.com/mattn/go-isatty"
 )
 
 type createCmdRunner struct {
@@ -30,6 +31,12 @@ type createCmdRunner struct {
 }
 
 func (r *createCmdRunner) run() error {
+	effectiveNonInteractive := r.nonInteractive
+	if !effectiveNonInteractive && !hasInteractiveSurveyTerminal(r.stdin, r.stderr) {
+		effectiveNonInteractive = true
+		_, _ = fmt.Fprintln(r.stdout, ui.Colors.InfoStyle.Render("No interactive terminal detected; running create in non-interactive mode."))
+	}
+
 	// 1. Get current branch info
 	parentBranch, err := git.GetCurrentBranch()
 	if err != nil {
@@ -91,7 +98,7 @@ func (r *createCmdRunner) run() error {
 		newBranchName = r.testBranchName
 	} else if r.branchNameArg != "" {
 		newBranchName = r.branchNameArg
-	} else if r.nonInteractive {
+	} else if effectiveNonInteractive {
 		return fmt.Errorf("branch name is required in non-interactive mode; pass it as an argument")
 	} else {
 		prompt := &survey.Input{Message: "Enter name for the new branch:"}
@@ -125,7 +132,7 @@ func (r *createCmdRunner) run() error {
 	if hasChanges {
 		if r.createMessage != "" {
 			commitMsg = r.createMessage
-		} else if r.nonInteractive {
+		} else if effectiveNonInteractive {
 			return fmt.Errorf("commit message is required in non-interactive mode when uncommitted changes exist; pass -m")
 		} else {
 			prompt := &survey.Input{Message: "Enter commit message for current changes:"}
@@ -169,7 +176,7 @@ func (r *createCmdRunner) run() error {
 		if r.testStageChoice != "" {
 			r.logger.Debug("Using stage choice from test flag", "testStageChoice", r.testStageChoice)
 			stageChoice = r.testStageChoice
-		} else if r.nonInteractive {
+		} else if effectiveNonInteractive {
 			stageChoice = "add-all"
 		} else {
 			prompt := &survey.Select{
@@ -274,4 +281,17 @@ func (r *createCmdRunner) run() error {
 	_, _ = fmt.Fprintln(r.stdout, ui.Colors.SuccessStyle.Render(finalMessage))
 
 	return nil
+}
+
+func hasInteractiveSurveyTerminal(stdin io.Reader, stderr io.Writer) bool {
+	stdinFile, ok := stdin.(*os.File)
+	if !ok {
+		return false
+	}
+	stderrFile, ok := stderr.(*os.File)
+	if !ok {
+		return false
+	}
+
+	return isatty.IsTerminal(stdinFile.Fd()) && isatty.IsTerminal(stderrFile.Fd())
 }

--- a/cli/so/cmd/create_test.go
+++ b/cli/so/cmd/create_test.go
@@ -2,6 +2,8 @@
 package cmd
 
 import (
+	"bytes"
+	"os"
 	"testing"
 
 	"github.com/benekuehn/socle/cli/so/internal/git"
@@ -141,4 +143,19 @@ func TestCreateCommand(t *testing.T) {
 	// TODO: Add test for 'add -p' but staging nothing (--test-addp-empty)
 	// TODO: Add test for invalid branch name
 	// TODO: Add test for creating off base branch directly
+}
+
+func TestHasInteractiveSurveyTerminal(t *testing.T) {
+	t.Run("Returns false for non-file stdio", func(t *testing.T) {
+		assert.False(t, hasInteractiveSurveyTerminal(bytes.NewBufferString(""), bytes.NewBufferString("")))
+	})
+
+	t.Run("Returns false for non-terminal file descriptors", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		defer r.Close()
+		defer w.Close()
+
+		assert.False(t, hasInteractiveSurveyTerminal(r, w))
+	})
 }


### PR DESCRIPTION
### Motivation
- Make the `so create` command safe to run in agent/CI/non-TTY environments by avoiding survey prompts when no interactive terminal is present.
- Ensure automation gets deterministic behavior (e.g., default staging choice) instead of hanging or failing on interactive prompts.

### Description
- Add terminal detection using `github.com/mattn/go-isatty` and a helper `hasInteractiveSurveyTerminal(stdin, stderr)` to detect interactive stdio.
- Introduce `effectiveNonInteractive` that falls back to non-interactive behavior when no TTY is detected and prints an informational message via `ui.Colors.InfoStyle`.
- Wire `effectiveNonInteractive` through all prompt code paths (branch name prompt, commit message prompt, staging-choice prompt) so prompts are skipped and safe defaults/errors are used.
- Add unit tests for the terminal detection helper in `cli/so/cmd/create_test.go` and update `cli/so/cmd/create_runner.go` accordingly.

### Testing
- Ran `cd cli/so && go test ./cmd -run TestHasInteractiveSurveyTerminal -v` and the test passed.
- Ran `cd cli/so && go test ./cmd -run TestCreateCommand -v` and the create command tests passed.
- Ran full `cd cli/so && go test ./...` and package tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea23cffe3c8332bc1dbd1fc400e095)