### PR TITLE
fix: support non-TTY execution for `so track`

### DIFF
--- a/cli/so/cmd/track_runner.go
+++ b/cli/so/cmd/track_runner.go
@@ -30,6 +30,12 @@ type trackCmdRunner struct {
 }
 
 func (r *trackCmdRunner) run() error {
+	effectiveNonInteractive := nonInteractive
+	if !effectiveNonInteractive && !hasInteractiveSurveyTerminal(r.stdin, r.stderr) {
+		effectiveNonInteractive = true
+		_, _ = fmt.Fprintln(r.stdout, ui.Colors.InfoStyle.Render("No interactive terminal detected; auto-selecting a parent branch for track."))
+	}
+
 	currentBranch, err := git.GetCurrentBranch()
 	if err != nil {
 		return fmt.Errorf("failed to get current branch: %w", err)
@@ -121,19 +127,29 @@ func (r *trackCmdRunner) run() error {
 		}
 		selectedParent = r.testSelectedParent
 	} else {
-		// Use runner's stdio
-		surveyOpts := survey.WithStdio(r.stdin.(*os.File), r.stderr.(*os.File), r.stderr.(*os.File))
-		r.logger.Debug("Prompting user for parent branch")
-		prompt := &survey.Select{Message: fmt.Sprintf("Select the parent branch for '%s':", currentBranch), Options: potentialParents}
-		if defaultParent != "" {
-			prompt.Default = defaultParent
+		if effectiveNonInteractive {
+			if defaultParent != "" {
+				selectedParent = defaultParent
+			} else {
+				selectedParent = potentialParents[0]
+			}
+			_, _ = fmt.Fprintf(r.stdout, "Using parent '%s' in non-interactive mode.\n", selectedParent)
+			r.logger.Debug("Parent selected in non-interactive mode", "selectedParent", selectedParent, "defaultParent", defaultParent)
+		} else {
+			// Use runner's stdio
+			surveyOpts := survey.WithStdio(r.stdin.(*os.File), r.stderr.(*os.File), r.stderr.(*os.File))
+			r.logger.Debug("Prompting user for parent branch")
+			prompt := &survey.Select{Message: fmt.Sprintf("Select the parent branch for '%s':", currentBranch), Options: potentialParents}
+			if defaultParent != "" {
+				prompt.Default = defaultParent
+			}
+			err := survey.AskOne(prompt, &selectedParent, surveyOpts)
+			if err != nil {
+				// Use ui.HandleSurveyInterrupt which should be in internal/ui
+				return ui.HandleSurveyInterrupt(err, "Track command cancelled.")
+			}
+			r.logger.Debug("Parent selected via prompt", "selectedParent", selectedParent)
 		}
-		err := survey.AskOne(prompt, &selectedParent, surveyOpts)
-		if err != nil {
-			// Use ui.HandleSurveyInterrupt which should be in internal/ui
-			return ui.HandleSurveyInterrupt(err, "Track command cancelled.")
-		}
-		r.logger.Debug("Parent selected via prompt", "selectedParent", selectedParent)
 	}
 
 	// 5. Determine and store base branch

--- a/cli/so/cmd/track_test.go
+++ b/cli/so/cmd/track_test.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"os"
 	"strings"
 	"testing"
 
@@ -42,6 +45,48 @@ func TestTrackCommand(t *testing.T) {
 		}
 		if base != "main" {
 			t.Errorf("Expected socle-base to be 'main', but got '%s'", base)
+		}
+	})
+
+	t.Run("Track auto-selects parent when no TTY is available", func(t *testing.T) {
+		repoPath, cleanup := testutils.SetupGitRepo(t)
+		defer cleanup()
+
+		testutils.RunCommand(t, repoPath, "git", "checkout", "-b", "feature/a")
+
+		originalNonInteractive := nonInteractive
+		nonInteractive = false
+		t.Cleanup(func() { nonInteractive = originalNonInteractive })
+
+		var stdout bytes.Buffer
+		var stderr bytes.Buffer
+		runner := &trackCmdRunner{
+			ctx:    context.Background(),
+			logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
+			stdout: &stdout,
+			stderr: &stderr,
+			stdin:  strings.NewReader(""),
+		}
+
+		err := runner.run()
+		if err != nil {
+			t.Fatalf("track runner failed in non-tty mode: %v", err)
+		}
+
+		parent, err := git.GetGitConfig("branch.feature/a.socle-parent")
+		if err != nil {
+			t.Fatalf("failed to get socle-parent config: %v", err)
+		}
+		if parent != "main" {
+			t.Errorf("expected auto-selected parent to be 'main', got '%s'", parent)
+		}
+
+		base, err := git.GetGitConfig("branch.feature/a.socle-base")
+		if err != nil {
+			t.Fatalf("failed to get socle-base config: %v", err)
+		}
+		if base != "main" {
+			t.Errorf("expected auto-selected base to be 'main', got '%s'", base)
 		}
 	})
 


### PR DESCRIPTION
### Motivation
- `so track` previously assumed TTY-backed stdio and attempted to use `survey` with `*os.File` stdio, which fails in agent/non-interactive environments.
- Make `track` robust when run by agents or in CI where stdin/stdout may not be a terminal.

### Description
- Detect non-interactive / non-TTY execution in `trackCmdRunner` and set `effectiveNonInteractive` accordingly using the existing `nonInteractive` flag and `hasInteractiveSurveyTerminal` helper.
- In non-interactive mode, auto-select a parent branch (`defaultParent` when discovered, otherwise the first candidate) instead of invoking a TTY prompt, and emit an informative message to stdout.
- Preserve interactive behavior when a terminal is present by continuing to use `survey` prompts.
- Add a unit test `Track auto-selects parent when no TTY is available` that constructs a `trackCmdRunner` with non-file `stdin`/`stdout` and verifies that branch parent/base config are set.

### Testing
- Ran `go test ./cmd -run TestTrackCommand -count=1`, which passed successfully.
- Ran full suite `go test ./...`, which completed successfully for the `cmd` package and produced no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff5f1a031083329ca7072e6f1987c0)